### PR TITLE
Handle ShaderTilemap and HigherTile

### DIFF
--- a/secret_passage/SecretPassage.js
+++ b/secret_passage/SecretPassage.js
@@ -14,69 +14,67 @@
  * @desc	The region number used for a secret passage - always passable. Character is invisible.
  * @default	3
  * 
+ * @param   Higher Tag
+ * @desc    The tile tag used for higher tile (for table tile). 1 to 15
+ * @default 1
+ * 
  * @help	
+ * 
  */
-var settings = PluginManager.parameters("SecretPassage");
-var passable_region = parseInt(settings["Passable"]) || 1;
-var impassable_region = parseInt(settings["Impassable"]) || 2;
-var invisible_region = parseInt(settings["Invisible"]) || 3;
-
-var _Game_Map_checkPassage = Game_Map.prototype.checkPassage;
-Game_Map.prototype.checkPassage = function(x, y, bit) {
-    var region = $gameMap.regionId(x, y);
-    switch (region) {
-        case passable_region:
-        case invisible_region: return true;
-        case impassable_region: return false;
-        default: return _Game_Map_checkPassage.call(this, x, y, bit);
-    }
-};
-
-var temp_mx = 0;
-var temp_my = 0;
-var tileId_below = 0;
-var Tilemap__paintTiles = Tilemap.prototype._paintTiles;
-Tilemap.prototype._paintTiles = function(startX, startY, x, y) {
-    temp_mx = startX + x;
-    temp_my = startY + y;
-    tileId_below = this._readMapData(temp_mx, temp_my + 1, 0); // only checks A type tiles
-    Tilemap__paintTiles.call(this, startX, startY, x, y);
-}
-
-var Tilemap__isHigherTile = Tilemap.prototype._isHigherTile;
-Tilemap.prototype._isHigherTile = function(tileId) {
-    var currentTile_invisibleRegion = this._readMapData(temp_mx, temp_my, 5) == invisible_region;
-    var tileOneBelow_invisibleRegion = this._readMapData(temp_mx, temp_my + 1, 5) == invisible_region;
-    var playerStandsBelow = $gamePlayer._realY > temp_my;
+(function () {
+    'use strict';
     
-    if (!tileOneBelow_invisibleRegion && playerStandsBelow) { // to show the hat tops
-        return Tilemap__isHigherTile.call(this, tileId);
-    }
-    if (currentTile_invisibleRegion) {
-        return 0x10;
-    }
-    if (tileOneBelow_invisibleRegion && Tilemap.isSameKindTile(tileId, tileId_below)) { // to hide the hat tops
-        return 0x10;
-    }
-    return Tilemap__isHigherTile.call(this, tileId);
-};
+    var settings = PluginManager.parameters("SecretPassage");
+    var passable_region = parseInt(settings["Passable"]) || 1;
+    var impassable_region = parseInt(settings["Impassable"]) || 2;
+    var invisible_region = parseInt(settings["Invisible"]) || 3;
+    var higher_flag = parseInt(settings["Higher Tag"]) << 12 || 0x1000;
 
+    var _Game_Map_checkPassage = Game_Map.prototype.checkPassage;
+    Game_Map.prototype.checkPassage = function (x, y, bit) {
+        var region = $gameMap.regionId(x, y);
+        switch (region) {
+            case passable_region:
+            case invisible_region: return true;
+            case impassable_region: return false;
+            default: return _Game_Map_checkPassage.call(this, x, y, bit);
+        }
+    };
 
+    var temp_mx = 0;
+    var temp_my = 0;
+    var tileId_below = 0;
+    var Tilemap__paintTiles = Tilemap.prototype._paintTiles;
+    Tilemap.prototype._paintTiles = function (startX, startY, x, y) {
+        temp_mx = startX + x;
+        temp_my = startY + y;
+        tileId_below = this._readMapData(temp_mx, temp_my + 1, 0); // only checks A type tiles
+        Tilemap__paintTiles.call(this, startX, startY, x, y);
+    };
 
+    var Tilemap__isHigherTile = Tilemap.prototype._isHigherTile;
+    Tilemap.prototype._isHigherTile = function (tileId) {
+        var currentTile_invisibleRegion = this._readMapData(temp_mx, temp_my, 5) == invisible_region;
+        var tileOneBelow_invisibleRegion = this._readMapData(temp_mx, temp_my + 1, 5) == invisible_region;
+        var playerStandsBelow = $gamePlayer._realY > temp_my;
 
+        if (!tileOneBelow_invisibleRegion && playerStandsBelow) { // to show the hat tops
+            return Tilemap__isHigherTile.call(this, tileId) || this.flags[tileId] & higher_flag;
+        }
+        if (currentTile_invisibleRegion) {
+            return 0x10;
+        }
+        if (tileOneBelow_invisibleRegion && Tilemap.isSameKindTile(tileId, tileId_below)) { // to hide the hat tops
+            return 0x10;
+        }
+        return Tilemap__isHigherTile.call(this, tileId) || this.flags[tileId] & higher_flag;
+    };
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    var ShaderTilemap__paintTiles = ShaderTilemap.prototype._paintTiles;
+    ShaderTilemap.prototype._paintTiles = function (startX, startY, x, y) {
+        temp_mx = startX + x;
+        temp_my = startY + y;
+        tileId_below = this._readMapData(temp_mx, temp_my + 1, 0); // only checks A type tiles
+        ShaderTilemap__paintTiles.call(this, startX, startY, x, y);
+    };
+})();


### PR DESCRIPTION
- Handle ShaderTilemap that added after RMMV v1.3.0
- For table tile, you can set tag to draw on upper layer.

tag means first 4bits of Tilemap.flags[tileId]. (sorry, I don't know it in English....)

tile that isHigherTile is true is drawn on upper layer.
so, on secret passage with invisible character, table tiles collapsed.
to fix it, draw same tiles on upper layer.
you can set tile tag of Higher Tag.